### PR TITLE
Add root route for game preview

### DIFF
--- a/billing/src/main/java/com/paymentchain/billing/controller/HomeController.java
+++ b/billing/src/main/java/com/paymentchain/billing/controller/HomeController.java
@@ -1,0 +1,13 @@
+package com.paymentchain.billing.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    @GetMapping("/")
+    public String index() {
+        return "forward:/index.html";
+    }
+}

--- a/billing/src/main/resources/static/game.js
+++ b/billing/src/main/resources/static/game.js
@@ -1,0 +1,237 @@
+const canvas = document.getElementById("game");
+const ctx = canvas.getContext("2d");
+const overlay = document.getElementById("overlay");
+const scoreEl = document.getElementById("score");
+const bestEl = document.getElementById("best");
+const restartBtn = document.getElementById("restart");
+
+const state = {
+  running: false,
+  score: 0,
+  best: 0,
+  gravity: 0.42,
+  flapStrength: -7.5,
+  speed: 2.2,
+  bird: {
+    x: 120,
+    y: 280,
+    radius: 22,
+    velocity: 0,
+    rotation: 0,
+  },
+  towers: [],
+  frame: 0,
+};
+
+const towerConfig = {
+  width: 70,
+  gap: 170,
+  spacing: 220,
+  minHeight: 120,
+};
+
+const cloudColors = ["rgba(255,255,255,0.9)", "rgba(255,255,255,0.6)"];
+const clouds = Array.from({ length: 6 }, (_, i) => ({
+  x: 80 + i * 120,
+  y: 40 + (i % 3) * 35,
+  speed: 0.4 + (i % 2) * 0.2,
+}));
+
+function resetGame() {
+  state.running = false;
+  state.score = 0;
+  state.bird.y = 280;
+  state.bird.velocity = 0;
+  state.bird.rotation = 0;
+  state.towers = [];
+  state.frame = 0;
+  scoreEl.textContent = "0";
+  overlay.classList.remove("hidden");
+}
+
+function startGame() {
+  if (state.running) return;
+  state.running = true;
+  overlay.classList.add("hidden");
+}
+
+function flap() {
+  if (!state.running) {
+    startGame();
+  }
+  state.bird.velocity = state.flapStrength;
+}
+
+function spawnTower() {
+  const maxHeight = canvas.height - towerConfig.gap - towerConfig.minHeight;
+  const topHeight = Math.floor(
+    towerConfig.minHeight + Math.random() * (maxHeight - towerConfig.minHeight)
+  );
+  state.towers.push({
+    x: canvas.width + towerConfig.width,
+    topHeight,
+    passed: false,
+  });
+}
+
+function updateBird() {
+  state.bird.velocity += state.gravity;
+  state.bird.y += state.bird.velocity;
+  state.bird.rotation = Math.min(Math.max(state.bird.velocity / 10, -0.5), 0.7);
+}
+
+function updateTowers() {
+  state.towers.forEach((tower) => {
+    tower.x -= state.speed;
+    if (!tower.passed && tower.x + towerConfig.width < state.bird.x) {
+      tower.passed = true;
+      state.score += 1;
+      scoreEl.textContent = state.score;
+      if (state.score > state.best) {
+        state.best = state.score;
+        bestEl.textContent = state.best;
+      }
+    }
+  });
+  if (state.towers.length && state.towers[0].x + towerConfig.width < -30) {
+    state.towers.shift();
+  }
+  if (state.frame % 130 === 0) {
+    spawnTower();
+  }
+}
+
+function updateClouds() {
+  clouds.forEach((cloud) => {
+    cloud.x -= cloud.speed;
+    if (cloud.x < -60) {
+      cloud.x = canvas.width + 50;
+    }
+  });
+}
+
+function checkCollision() {
+  if (state.bird.y - state.bird.radius < 0 || state.bird.y + state.bird.radius > canvas.height) {
+    return true;
+  }
+  return state.towers.some((tower) => {
+    const withinX =
+      state.bird.x + state.bird.radius > tower.x &&
+      state.bird.x - state.bird.radius < tower.x + towerConfig.width;
+    if (!withinX) return false;
+    const topCollision = state.bird.y - state.bird.radius < tower.topHeight;
+    const bottomCollision =
+      state.bird.y + state.bird.radius > tower.topHeight + towerConfig.gap;
+    return topCollision || bottomCollision;
+  });
+}
+
+function drawClouds() {
+  clouds.forEach((cloud, index) => {
+    ctx.fillStyle = cloudColors[index % cloudColors.length];
+    ctx.beginPath();
+    ctx.ellipse(cloud.x, cloud.y, 28, 14, 0, 0, Math.PI * 2);
+    ctx.ellipse(cloud.x + 20, cloud.y + 6, 20, 12, 0, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function drawBird() {
+  ctx.save();
+  ctx.translate(state.bird.x, state.bird.y);
+  ctx.rotate(state.bird.rotation);
+  ctx.fillStyle = "#f4a261";
+  ctx.beginPath();
+  ctx.arc(0, 0, state.bird.radius, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = "#1d1d1d";
+  ctx.fillRect(-12, -12, 24, 8);
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(-8, -10, 8, 4);
+
+  ctx.fillStyle = "#ffb703";
+  ctx.beginPath();
+  ctx.moveTo(state.bird.radius - 2, 0);
+  ctx.lineTo(state.bird.radius + 14, 6);
+  ctx.lineTo(state.bird.radius + 14, -6);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = "#8d5524";
+  ctx.fillText("CAGE", -16, 28);
+  ctx.restore();
+}
+
+function drawTowers() {
+  ctx.fillStyle = "#2a9d8f";
+  ctx.strokeStyle = "#0f3d3e";
+  ctx.lineWidth = 4;
+
+  state.towers.forEach((tower) => {
+    ctx.fillRect(tower.x, 0, towerConfig.width, tower.topHeight);
+    ctx.strokeRect(tower.x, 0, towerConfig.width, tower.topHeight);
+
+    const bottomY = tower.topHeight + towerConfig.gap;
+    ctx.fillRect(tower.x, bottomY, towerConfig.width, canvas.height - bottomY);
+    ctx.strokeRect(tower.x, bottomY, towerConfig.width, canvas.height - bottomY);
+  });
+}
+
+function drawGround() {
+  const gradient = ctx.createLinearGradient(0, canvas.height - 80, 0, canvas.height);
+  gradient.addColorStop(0, "#2b2d42");
+  gradient.addColorStop(1, "#0b0d17");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, canvas.height - 80, canvas.width, 80);
+}
+
+function drawScore() {
+  ctx.fillStyle = "rgba(255,255,255,0.85)";
+  ctx.font = "24px 'Segoe UI', sans-serif";
+  ctx.fillText(`Puntuación: ${state.score}`, 20, 40);
+}
+
+function update() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawClouds();
+  drawTowers();
+  drawGround();
+  drawBird();
+  drawScore();
+
+  if (!state.running) {
+    return;
+  }
+
+  updateBird();
+  updateTowers();
+  updateClouds();
+
+  if (checkCollision()) {
+    state.running = false;
+    overlay.querySelector("h2").textContent = "¡Chocaste! Presiona para reiniciar";
+    overlay.classList.remove("hidden");
+  }
+
+  state.frame += 1;
+  window.requestAnimationFrame(update);
+}
+
+window.addEventListener("keydown", (event) => {
+  if (event.code === "Space") {
+    event.preventDefault();
+    flap();
+  }
+});
+
+canvas.addEventListener("pointerdown", () => flap());
+restartBtn.addEventListener("click", () => {
+  resetGame();
+  startGame();
+  state.frame = 0;
+  window.requestAnimationFrame(update);
+});
+
+resetGame();
+window.requestAnimationFrame(update);

--- a/billing/src/main/resources/static/index.html
+++ b/billing/src/main/resources/static/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Flapping Cage Remake</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="game-shell">
+    <header class="header">
+      <div>
+        <p class="eyebrow">Remake Web</p>
+        <h1>Flapping Cage</h1>
+        <p class="subtitle">Ayuda a Cage a atravesar el cielo sin tocar las torres.</p>
+      </div>
+      <div class="scoreboard">
+        <div>
+          <span class="label">Puntuación</span>
+          <span id="score" class="value">0</span>
+        </div>
+        <div>
+          <span class="label">Mejor</span>
+          <span id="best" class="value">0</span>
+        </div>
+      </div>
+    </header>
+
+    <section class="canvas-wrapper">
+      <canvas id="game" width="420" height="640" aria-label="Juego Flapping Cage"></canvas>
+      <div id="overlay" class="overlay" role="status">
+        <h2>Presiona espacio o toca para empezar</h2>
+        <p>Espacio / Click / Tap: Aletear</p>
+      </div>
+    </section>
+
+    <footer class="controls">
+      <button id="restart" class="btn">Reiniciar partida</button>
+      <p>Consejo: Mantén el ritmo y evita las torres.</p>
+    </footer>
+  </main>
+
+  <script src="game.js"></script>
+</body>
+</html>

--- a/billing/src/main/resources/static/styles.css
+++ b/billing/src/main/resources/static/styles.css
@@ -1,0 +1,143 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background: #0b0d17;
+  color: #f4f7ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  background: radial-gradient(circle at top, #1b2240 0%, #090b12 65%);
+}
+
+.game-shell {
+  width: min(900px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.7rem;
+  color: #8bd7ff;
+  margin: 0 0 4px;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 3rem);
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: #cbd4ff;
+}
+
+.scoreboard {
+  display: flex;
+  gap: 24px;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 12px 18px;
+  border-radius: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.label {
+  display: block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  color: #99a7ff;
+}
+
+.value {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.canvas-wrapper {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: linear-gradient(180deg, #4cc9f0 0%, #0c1b3a 70%, #04060c 100%);
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(5, 9, 20, 0.65);
+  text-align: center;
+  padding: 24px;
+  gap: 8px;
+  transition: opacity 0.2s ease;
+}
+
+.overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: #a7b1ff;
+}
+
+.btn {
+  background: #ffb703;
+  border: none;
+  border-radius: 999px;
+  padding: 12px 22px;
+  font-weight: 600;
+  color: #2b1d00;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(255, 183, 3, 0.35);
+}
+
+.btn:hover {
+  background: #ffd166;
+}
+
+@media (max-width: 720px) {
+  .scoreboard {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
### Motivation
- La vista previa del servicio devolvía "not found" al visitar la raíz, por lo que es necesario enrutar `/` al `index.html` estático del remake Flapping Cage.
- Mantener los assets del juego integrados en el módulo `billing` para poder mostrar un demo web rápido desde la app.

### Description
- Se añadió el controlador `HomeController` con `@GetMapping("/")` que devuelve `forward:/index.html` en `billing/src/main/java/com/paymentchain/billing/controller/HomeController.java` para servir la vista al root.
- Se añadieron los assets estáticos en `billing/src/main/resources/static/`: `index.html`, `styles.css` y `game.js` que implementan la UI, estilos y la lógica del juego en canvas respectivamente.
- `game.js` contiene la física del pájaro, generación y movimiento de torres, detección de colisiones, marcador y controles de inicio/reinicio; `styles.css` aplica diseño responsivo y estética nocturna.

### Testing
- Los archivos estáticos se verificaron previamente sirviéndolos con `python -m http.server 8000` y con un script de Playwright que navegó a `http://127.0.0.1:8000/` y generó la captura `artifacts/flapping-cage.png`, y esa comprobación finalizó con éxito.
- No se ejecutaron pruebas automatizadas adicionales para el cambio de routing (`HomeController`) porque es una modificación de enrutamiento simple.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987660370e0832c83213325a9d6f33b)