### PR TITLE
Agregar publicación automática y manual de carteleras UFC con webhook de Discord

### DIFF
--- a/billing/pom.xml
+++ b/billing/pom.xml
@@ -104,6 +104,11 @@
             <scope>test</scope>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>net.dv8tion</groupId>
+            <artifactId>JDA</artifactId>
+            <version>5.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/billing/src/main/java/com/paymentchain/billing/BillingApplication.java
+++ b/billing/src/main/java/com/paymentchain/billing/BillingApplication.java
@@ -1,0 +1,14 @@
+package com.paymentchain.billing;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class BillingApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BillingApplication.class, args);
+    }
+}

--- a/billing/src/main/java/com/paymentchain/billing/DiscordBotRunner.java
+++ b/billing/src/main/java/com/paymentchain/billing/DiscordBotRunner.java
@@ -1,0 +1,36 @@
+package com.paymentchain.billing;
+
+import javax.annotation.PostConstruct;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DiscordBotRunner {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiscordBotRunner.class);
+
+    private final UfcSchedulePoster schedulePoster;
+    private final String botToken;
+
+    public DiscordBotRunner(UfcSchedulePoster schedulePoster,
+                            @Value("${discord.bot-token:}") String botToken) {
+        this.schedulePoster = schedulePoster;
+        this.botToken = botToken;
+    }
+
+    @PostConstruct
+    public void startBot() {
+        if (botToken == null || botToken.isBlank()) {
+            LOGGER.warn("Discord bot token not configured. Bot commands are disabled.");
+            return;
+        }
+        JDABuilder.createDefault(botToken, GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT)
+            .setActivity(Activity.watching("carteleras UFC"))
+            .addEventListeners(new DiscordCommandListener(schedulePoster))
+            .build();
+    }
+}

--- a/billing/src/main/java/com/paymentchain/billing/DiscordCommandListener.java
+++ b/billing/src/main/java/com/paymentchain/billing/DiscordCommandListener.java
@@ -1,0 +1,32 @@
+package com.paymentchain.billing;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.springframework.lang.NonNull;
+
+public class DiscordCommandListener extends ListenerAdapter {
+    private final UfcSchedulePoster schedulePoster;
+
+    public DiscordCommandListener(UfcSchedulePoster schedulePoster) {
+        this.schedulePoster = schedulePoster;
+    }
+
+    @Override
+    public void onMessageReceived(@NonNull MessageReceivedEvent event) {
+        if (event.getAuthor().isBot()) {
+            return;
+        }
+        String content = event.getMessage().getContentRaw().trim();
+        if (!content.equalsIgnoreCase("!ufc")
+            && !content.equalsIgnoreCase("!ufc cartelera")
+            && !content.equalsIgnoreCase("!ufc carteleras")) {
+            return;
+        }
+        String message = schedulePoster.buildUpcomingEventsMessage();
+        if (message == null) {
+            event.getChannel().sendMessage("No hay carteleras futuras disponibles.").queue();
+            return;
+        }
+        event.getChannel().sendMessage(message).queue();
+    }
+}

--- a/billing/src/main/java/com/paymentchain/billing/DiscordWebhookClient.java
+++ b/billing/src/main/java/com/paymentchain/billing/DiscordWebhookClient.java
@@ -1,0 +1,33 @@
+package com.paymentchain.billing;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class DiscordWebhookClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiscordWebhookClient.class);
+
+    private final RestTemplate restTemplate;
+    private final String webhookUrl;
+
+    public DiscordWebhookClient(RestTemplate restTemplate,
+                                @Value("${discord.webhook-url:}") String webhookUrl) {
+        this.restTemplate = restTemplate;
+        this.webhookUrl = webhookUrl;
+    }
+
+    public void sendMessage(String message) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            LOGGER.warn("Discord webhook URL not configured. Skipping message.");
+            return;
+        }
+        Map<String, String> payload = new HashMap<>();
+        payload.put("content", message);
+        restTemplate.postForEntity(webhookUrl, payload, String.class);
+    }
+}

--- a/billing/src/main/java/com/paymentchain/billing/RestTemplateConfig.java
+++ b/billing/src/main/java/com/paymentchain/billing/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.paymentchain.billing;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/billing/src/main/java/com/paymentchain/billing/UfcEvent.java
+++ b/billing/src/main/java/com/paymentchain/billing/UfcEvent.java
@@ -1,0 +1,27 @@
+package com.paymentchain.billing;
+
+import java.time.ZonedDateTime;
+
+public class UfcEvent {
+    private final String name;
+    private final ZonedDateTime date;
+    private final String venue;
+
+    public UfcEvent(String name, ZonedDateTime date, String venue) {
+        this.name = name;
+        this.date = date;
+        this.venue = venue;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ZonedDateTime getDate() {
+        return date;
+    }
+
+    public String getVenue() {
+        return venue;
+    }
+}

--- a/billing/src/main/java/com/paymentchain/billing/UfcEventsService.java
+++ b/billing/src/main/java/com/paymentchain/billing/UfcEventsService.java
@@ -1,0 +1,76 @@
+package com.paymentchain.billing;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class UfcEventsService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UfcEventsService.class);
+
+    private final RestTemplate restTemplate;
+    private final String eventsUrl;
+    private final ZoneId zoneId;
+
+    public UfcEventsService(RestTemplate restTemplate,
+                            @Value("${ufc.events-url}") String eventsUrl,
+                            @Value("${ufc.timezone:UTC}") String timezone) {
+        this.restTemplate = restTemplate;
+        this.eventsUrl = eventsUrl;
+        this.zoneId = ZoneId.of(timezone);
+    }
+
+    public List<UfcEvent> fetchUpcomingEvents() {
+        JsonNode payload = restTemplate.getForObject(eventsUrl, JsonNode.class);
+        List<UfcEvent> events = new ArrayList<>();
+        if (payload == null) {
+            LOGGER.warn("UFC events payload is empty from {}", eventsUrl);
+            return events;
+        }
+        JsonNode eventsNode = payload.path("events");
+        if (!eventsNode.isArray()) {
+            LOGGER.warn("UFC events payload does not contain an events array.");
+            return events;
+        }
+        ZonedDateTime now = ZonedDateTime.now(zoneId);
+        for (JsonNode eventNode : eventsNode) {
+            String name = eventNode.path("name").asText("Evento UFC");
+            String dateText = eventNode.path("date").asText(null);
+            ZonedDateTime eventDate = parseDate(dateText);
+            if (eventDate == null || eventDate.isBefore(now)) {
+                continue;
+            }
+            String state = eventNode.path("status").path("type").path("state").asText("");
+            boolean isUpcoming = state.isEmpty() || "pre".equalsIgnoreCase(state);
+            if (!isUpcoming) {
+                continue;
+            }
+            String venue = eventNode.path("competitions").path(0).path("venue").path("fullName")
+                .asText("Por confirmar");
+            events.add(new UfcEvent(name, eventDate, venue));
+        }
+        events.sort(Comparator.comparing(UfcEvent::getDate));
+        return events;
+    }
+
+    private ZonedDateTime parseDate(String dateText) {
+        if (dateText == null || dateText.isBlank()) {
+            return null;
+        }
+        try {
+            return OffsetDateTime.parse(dateText).atZoneSameInstant(zoneId);
+        } catch (Exception ex) {
+            LOGGER.warn("Unable to parse UFC event date: {}", dateText, ex);
+            return null;
+        }
+    }
+}

--- a/billing/src/main/java/com/paymentchain/billing/UfcScheduleController.java
+++ b/billing/src/main/java/com/paymentchain/billing/UfcScheduleController.java
@@ -1,0 +1,22 @@
+package com.paymentchain.billing;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ufc")
+public class UfcScheduleController {
+    private final UfcSchedulePoster schedulePoster;
+
+    public UfcScheduleController(UfcSchedulePoster schedulePoster) {
+        this.schedulePoster = schedulePoster;
+    }
+
+    @PostMapping("/post")
+    public ResponseEntity<String> postUpcomingEvents() {
+        schedulePoster.postUpcomingEvents();
+        return ResponseEntity.ok("UFC schedule posted if available.");
+    }
+}

--- a/billing/src/main/java/com/paymentchain/billing/UfcSchedulePoster.java
+++ b/billing/src/main/java/com/paymentchain/billing/UfcSchedulePoster.java
@@ -1,0 +1,47 @@
+package com.paymentchain.billing;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UfcSchedulePoster {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UfcSchedulePoster.class);
+
+    private final UfcEventsService eventsService;
+    private final DiscordWebhookClient webhookClient;
+    private final DateTimeFormatter formatter;
+
+    public UfcSchedulePoster(UfcEventsService eventsService,
+                             DiscordWebhookClient webhookClient,
+                             @Value("${ufc.date-format:dd MMM yyyy HH:mm z}") String dateFormat) {
+        this.eventsService = eventsService;
+        this.webhookClient = webhookClient;
+        this.formatter = DateTimeFormatter.ofPattern(dateFormat, new Locale("es", "ES"));
+    }
+
+    @Scheduled(cron = "${ufc.cron:0 0 9 * * *}")
+    public void postUpcomingEvents() {
+        List<UfcEvent> events = eventsService.fetchUpcomingEvents();
+        if (events.isEmpty()) {
+            LOGGER.info("No upcoming UFC events found.");
+            return;
+        }
+        StringBuilder message = new StringBuilder("**Próximas carteleras de UFC**\n");
+        for (UfcEvent event : events) {
+            message.append("• ")
+                .append(event.getName())
+                .append(" — ")
+                .append(event.getDate().format(formatter))
+                .append(" — ")
+                .append(event.getVenue())
+                .append("\n");
+        }
+        webhookClient.sendMessage(message.toString());
+    }
+}

--- a/billing/src/main/java/com/paymentchain/billing/UfcSchedulePoster.java
+++ b/billing/src/main/java/com/paymentchain/billing/UfcSchedulePoster.java
@@ -27,11 +27,23 @@ public class UfcSchedulePoster {
 
     @Scheduled(cron = "${ufc.cron:0 0 9 * * *}")
     public void postUpcomingEvents() {
-        List<UfcEvent> events = eventsService.fetchUpcomingEvents();
-        if (events.isEmpty()) {
+        String message = buildUpcomingEventsMessage();
+        if (message == null) {
             LOGGER.info("No upcoming UFC events found.");
             return;
         }
+        webhookClient.sendMessage(message);
+    }
+
+    public String buildUpcomingEventsMessage() {
+        List<UfcEvent> events = eventsService.fetchUpcomingEvents();
+        if (events.isEmpty()) {
+            return null;
+        }
+        return buildMessage(events);
+    }
+
+    public String buildMessage(List<UfcEvent> events) {
         StringBuilder message = new StringBuilder("**Próximas carteleras de UFC**\n");
         for (UfcEvent event : events) {
             message.append("• ")
@@ -42,6 +54,6 @@ public class UfcSchedulePoster {
                 .append(event.getVenue())
                 .append("\n");
         }
-        webhookClient.sendMessage(message.toString());
+        return message.toString();
     }
 }

--- a/billing/src/main/resources/application.properties
+++ b/billing/src/main/resources/application.properties
@@ -8,3 +8,12 @@ spring.datasource.password=qwerty
 
 # swagger-ui custom path
 springdoc.swagger-ui.path=/swagger-ui/index.html
+# UFC Discord bot configuration
+ufc.events-url=https://site.web.api.espn.com/apis/v2/sports/mma/ufc/scoreboard
+ufc.timezone=UTC
+ufc.date-format=dd MMM yyyy HH:mm z
+ufc.cron=0 0 9 * * *
+
+# Discord webhook for posting UFC schedules
+# Configure via environment variable DISCORD_WEBHOOK_URL or directly here.
+discord.webhook-url=${DISCORD_WEBHOOK_URL:}

--- a/billing/src/main/resources/application.properties
+++ b/billing/src/main/resources/application.properties
@@ -17,3 +17,6 @@ ufc.cron=0 0 9 * * *
 # Discord webhook for posting UFC schedules
 # Configure via environment variable DISCORD_WEBHOOK_URL or directly here.
 discord.webhook-url=${DISCORD_WEBHOOK_URL:}
+
+# Discord bot token for command-based posting
+discord.bot-token=${DISCORD_BOT_TOKEN:}


### PR DESCRIPTION
### Motivation
- Añadir un servicio programado que consulte la API pública de eventos de UFC y publique las próximas carteleras en un canal de Discord vía webhook.
- Evitar almacenar secretos en el repositorio y permitir configuración segura del webhook mediante la variable de entorno `DISCORD_WEBHOOK_URL`.
- Permitir disparo manual de la publicación mediante un endpoint HTTP para facilitar pruebas y operaciones ad-hoc.

### Description
- Habilitado scheduling en la app con `@EnableScheduling` añadiendo `BillingApplication` y configurado `RestTemplate` vía `RestTemplateConfig`.
- Implementado `UfcEventsService` que consulta `ufc.events-url`, parsea el JSON, filtra eventos futuros y los normaliza a `UfcEvent` respetando `ufc.timezone`.
- Añadido `UfcSchedulePoster` con `@Scheduled(cron = "${ufc.cron:0 0 9 * * *}")` para formatear y publicar las carteleras usando `DiscordWebhookClient` que lee `discord.webhook-url` desde `DISCORD_WEBHOOK_URL`.
- Añadido endpoint manual `POST /ufc/post` en `UfcScheduleController` para forzar el envío inmediato; actualizado `application.properties` con propiedades `ufc.*` y `discord.webhook-url`.

### Testing
- No se ejecutaron tests unitarios o de integración automatizados en este cambio.
- Se intentó validar la llamada a la API pública (ESPN) pero la petición devolvió `403 Forbidden`, impidiendo la validación en tiempo de ejecución del flujo de eventos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a69151934832caa41ef592dbf07d8)